### PR TITLE
allow passing of cellId for holochainClient

### DIFF
--- a/src/cell-client.ts
+++ b/src/cell-client.ts
@@ -7,7 +7,8 @@ export interface CellClient {
     zomeName: string,
     fnName: string,
     payload: any,
-    timeout?: number
+    timeout?: number,
+    cellId?: CellId
   ): Promise<any>;
 
   addSignalHandler(

--- a/src/holochain-client.ts
+++ b/src/holochain-client.ts
@@ -21,7 +21,8 @@ export class HolochainClient extends BaseClient implements CellClient {
     zomeName: string,
     fnName: string,
     payload: any,
-    timeout = 15000
+    timeout = 15000,
+    cellId = this.cellId[1]
   ): Promise<any> {
     return this.appWebsocket.callZome(
       {
@@ -30,7 +31,7 @@ export class HolochainClient extends BaseClient implements CellClient {
         zome_name: zomeName,
         fn_name: fnName,
         payload: payload,
-        provenance: this.cellId[1],
+        provenance: cellId,
       },
       timeout
     );


### PR DESCRIPTION
This is needed for when a Happ implements cloning of DNA as cellId differs per cloned DNA (currently in the form of Happ) which needs to be specified in callZome